### PR TITLE
Improvements to memcached gather module

### DIFF
--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -11,7 +11,8 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
+    super(update_info(
+      info,
       'Name'          => 'Memcached Extractor',
       'Description'   => %q(
         This module extracts the slabs from a memcached instance.  It then
@@ -33,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('MAXKEYS', [ true, 'Maximum number of keys to be pulled from a slab', 100] )
+        OptInt.new('MAXKEYS', [true, 'Maximum number of keys to be pulled from a slab', 100])
       ], self.class
     )
   end
@@ -104,7 +105,7 @@ class Metasploit3 < Msf::Auxiliary
     vprint_status("#{peer} - Connecting to memcached server...")
     begin
       connect
-      if version = determine_version
+      if (version = determine_version)
         vprint_good("#{peer} - Connected to memcached version #{version}")
         report_service(
           host: ip,

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -23,9 +23,15 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(11211),
+        Opt::RPORT(11211)
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
         OptInt.new('MAXKEYS', [ true, 'Maximum number of keys to be pulled from a slab', 100] )
-      ], self.class)
+      ], self.class
+    )
   end
 
   def max_keys

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -126,7 +126,7 @@ class Metasploit3 < Msf::Auxiliary
         print_good("#{peer} - memcached loot stored as #{path}")
       end
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout
-      print_error("#{peer} - Could not connect to memcached server!")
+      vprint_error("#{peer} - Could not connect to memcached server!")
     end
   end
 end

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -80,9 +80,9 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def determine_version
-    sock.send("stats\r\n", 0)
+    sock.send("version\r\n", 0)
     stats = sock.recv(4096)
-    if /^STAT version (?<version>[\d\.]+)/ =~ stats
+    if /^VERSION (?<version>[\d\.]+)/ =~ stats
       version
     else
       nil

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -18,7 +18,11 @@ class Metasploit3 < Msf::Auxiliary
         finds the keys and values stored in those slabs.
       ),
       'Author'        => [ 'Paul Deardorff <paul_deardorff[at]rapid7.com>' ],
-      'License'       => MSF_LICENSE
+      'License'       => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt']
+        ]
     ))
 
     register_options(

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -87,12 +87,13 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_status("#{ip}:#{rport} - Connecting to memcached server...")
+    peer = "#{ip}:#{rport}"
+    vprint_status("#{peer} - Connecting to memcached server...")
     begin
       connect
-      print_good("Connected to memcached #{determine_version}")
+      vprint_good("#{peer} Connected to memcached #{determine_version}")
       keys = enumerate_keys
-      print_good("Found #{keys.size} keys")
+      print_good("#{peer} Found #{keys.size} keys")
       return if keys.size == 0
 
       data = data_for_keys(keys)
@@ -106,11 +107,11 @@ class Metasploit3 < Msf::Auxiliary
         print_line
         print_line("#{result_table}")
       else
-        store_loot('memcached.dump', 'text/plain', ip, data, 'memcached.txt', 'Memcached extractor')
-        print_good("Loot stored!")
+        path = store_loot('memcached.dump', 'text/plain', ip, data, 'memcached.txt', 'Memcached extractor')
+        print_good("#{peer} - memcached loot stored as #{path}")
       end
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout
-      print_error("Could not connect to memcached server!")
+      print_error("#{peer} - Could not connect to memcached server!")
     end
   end
 end


### PR DESCRIPTION
Various simple improvements to your memcached gather module.  

No keys, non-verbose:

```
msf auxiliary(memcached_extractor) > run

[+] 10.4.21.44:11211 - Found 0 keys
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Some keys, verbose:

```
msf auxiliary(memcached_extractor) > run

[*] 10.4.21.44:11211 - Connecting to memcached server...
[+] 10.4.21.44:11211 - Connected to memcached version 1.4.13
[+] 10.4.21.44:11211 - Found 1 keys
[+] 10.4.21.44:11211 - memcached loot stored as /home/jhart/.msf4/loot/20150120085607_default_10.4.21.44_memcached.dump_306193.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
